### PR TITLE
Image sizes

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -218,11 +218,31 @@ class Subject
   end
 
   def width
-    return FastImage.size(self.image[0])[0]
+    begin
+      return self.image_size[0]
+    rescue
+      return 0
+    end
   end
 
   def height
-    return FastImage.size(self.image[0])[1]
+    begin
+      return self.image_size[1]
+    rescue
+      return 0
+    end
+  end
+  
+  def image_size
+    @size ||= []
+    if @size.empty?
+      begin
+        @size = FastImage.size(self.image[0], :raise_on_failure=>true)
+      rescue
+        @size = [self.metadata["original_size"]["width"], self.metadata["original_size"]["height"]]
+      end
+    end
+    @size
   end
 
   def pixel_scale


### PR DESCRIPTION
Catch network errors from FastImage.
Return subject original size on error.
Cache FastImage calls for speed

Fixes some bugs with images not showing up if the http request for the image size failed. Also, making separate requests to get height and width.
